### PR TITLE
Add additionalArgs and workingDir configuration settings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,6 +45,8 @@ shellcheck {
     isUseDocker = true
     shellcheckBinary = "/usr/local/bin/shellcheck"
     installer = "brew"
+    additionalArguments = "-x"
+    workingDir = file("${buildDir}/scripts")
 }
 ----
 
@@ -59,6 +61,8 @@ is not supported yet.
 * installer - for a machine without Docker or the shellcheck binary being installed, provide the installer to be used. It supports
 the ones mentioned https://github.com/koalaman/shellcheck#installing[here] under the Unix family. By default, none. Ignored if `useDocker` is `true`.
 * severity - Minimum severity of errors to consider (error, warning, info, style). Defaults to `style`.
+* additionalArguments - Additional arguments to pass to shellcheck.
+* workingDir - Sets the working directory to run shellcheck from. Defaults to the project directory.
 
 [[sec:shellcheck_customize_xsl]]
 == Customizing the HTML report

--- a/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
+++ b/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
@@ -10,7 +10,7 @@ abstract class BaseShellcheckPluginFuncTest extends BaseInfraTest {
 shellcheck {
     sources = files("${resources.absolutePath}/with_violations")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
@@ -36,7 +36,7 @@ shellcheck {
 shellcheck {
     sources = files("${resources.absolutePath}/without_violations")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
@@ -50,7 +50,7 @@ shellcheck {
 shellcheck {
     sources = files("${resources.absolutePath}/without_violations", "${resources.absolutePath}/another_without_violations")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
@@ -86,7 +86,7 @@ shellcheck {
     sources = files("${resources.absolutePath}/with_violations")
     isIgnoreFailures = true
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
@@ -100,12 +100,40 @@ shellcheck {
 shellcheck {
     sources = files("${resources.absolutePath}/no_shell_scripts")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
         expect:
         runner().build()
+    }
+
+    def "pass the build when valid additional arguments are provided"() {
+        given:
+        buildFile << """
+shellcheck {
+    sources = files("${resources.absolutePath}/wihtout_violations")
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+    additionalArguments = "-a -x"
+}
+"""
+        expect:
+        runner().build()
+    }
+
+    def "fail the build when invalid additional arguments are provided"() {
+        given:
+        buildFile << """
+shellcheck {
+    sources = files("${resources.absolutePath}/wihtout_violations")
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+    additionalArguments = "--bad-arg"
+}
+"""
+        expect:
+        runner().buildAndFail()
     }
 
     def "only generate html reports"() {
@@ -114,7 +142,7 @@ shellcheck {
 shellcheck {
     sources = files("${resources.absolutePath}/with_violations")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 
 tasks.withType<com.felipefzdz.gradle.shellcheck.Shellcheck>().configureEach {
@@ -140,7 +168,7 @@ tasks.withType<com.felipefzdz.gradle.shellcheck.Shellcheck>().configureEach {
 shellcheck {
     sources = files("${resources.absolutePath}/with_violations")
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 
@@ -160,7 +188,7 @@ shellcheck {
     sources = files("${resources.absolutePath}/with_violations")
     severity = "error"
     useDocker = $useDocker
-    shellcheckBinary = "$shellcheckBinary" 
+    shellcheckBinary = "$shellcheckBinary"
 }
 """
 

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
@@ -15,9 +15,9 @@ public class Shell {
     static String run(String command, File projectDir, Logger logger) throws IOException, InterruptedException {
         return run(asList(command.split("\\s+")), projectDir, logger);
     }
-    static String run(List<String> command, File projectDir, Logger logger) throws IOException, InterruptedException {
+    static String run(List<String> command, File workingDir, Logger logger) throws IOException, InterruptedException {
         ProcessBuilder builder = new ProcessBuilder(command)
-                .directory(projectDir)
+                .directory(workingDir)
                 .redirectOutput(ProcessBuilder.Redirect.PIPE)
                 .redirectErrorStream(true);
         prepareEnvironment(logger, builder.environment());

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
@@ -36,6 +36,7 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
     private String shellcheckBinary;
     private String installer;
     private File projectDir;
+    private String additionalArguments;
 
     public Shellcheck() {
         this.reports = (ShellcheckReports) getObjectFactory().newInstance(ShellcheckReportsImpl.class, this);
@@ -204,5 +205,14 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
 
     public void setInstaller(String installer) {
         this.installer = installer;
+    }
+
+    @Input
+    public String getAdditionalArguments() {
+        return additionalArguments;
+    }
+
+    public void setAdditionalArguments(String additionalArguments) {
+        this.additionalArguments = additionalArguments;
     }
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
@@ -35,7 +35,7 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
     private String severity;
     private String shellcheckBinary;
     private String installer;
-    private File projectDir;
+    private File workingDir;
     private String additionalArguments;
 
     public Shellcheck() {
@@ -172,12 +172,12 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
     }
 
     @Internal
-    public File getProjectDir() {
-        return projectDir;
+    public File getWorkingDir() {
+        return workingDir;
     }
 
-    public void setProjectDir(File projectDir) {
-        this.projectDir = projectDir;
+    public void setWorkingDir(File workingDir) {
+        this.workingDir = workingDir;
     }
 
     @Input

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
@@ -4,6 +4,8 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
 
+import java.io.File;
+
 public class ShellcheckExtension extends CodeQualityExtension {
 
     private final Project project;
@@ -16,9 +18,11 @@ public class ShellcheckExtension extends CodeQualityExtension {
     private String shellcheckBinary = "/usr/local/bin/shellcheck";
     private String installer = "";
     private String additionalArguments = "";
+    private File workingDir;
 
     public ShellcheckExtension(Project project) {
         this.project = project;
+        this.workingDir = project.getProjectDir();
     }
 
     public FileCollection getSources() {
@@ -97,5 +101,13 @@ public class ShellcheckExtension extends CodeQualityExtension {
 
     public void setAdditionalArguments(String additionalArguments) {
         this.additionalArguments = additionalArguments;
+    }
+
+    public File getWorkingDir() {
+        return workingDir;
+    }
+
+    public void setWorkingDir(File workingDir) {
+        this.workingDir = workingDir;
     }
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
@@ -15,6 +15,7 @@ public class ShellcheckExtension extends CodeQualityExtension {
     private boolean useDocker = true;
     private String shellcheckBinary = "/usr/local/bin/shellcheck";
     private String installer = "";
+    private String additionalArguments = "";
 
     public ShellcheckExtension(Project project) {
         this.project = project;
@@ -88,5 +89,13 @@ public class ShellcheckExtension extends CodeQualityExtension {
 
     public void setInstaller(String installer) {
         this.installer = installer;
+    }
+
+    public String getAdditionalArguments() {
+        return additionalArguments;
+    }
+
+    public void setAdditionalArguments(String additionalArguments) {
+        this.additionalArguments = additionalArguments;
     }
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckInvoker.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckInvoker.java
@@ -148,7 +148,7 @@ public class ShellcheckInvoker {
 
         maybePrepareCommandToUserDocker(command, sources, task.getShellcheckVersion(), task.isUseDocker());
         final String shellcheckBinary = task.isUseDocker() ? "shellcheck" : task.getShellcheckBinary();
-        String cmd = findCommand(sources.stream().map(File::getAbsolutePath).collect(joining(" "))) + " | xargs " + shellcheckBinary + " -f " + format + " --severity=" + task.getSeverity();
+        String cmd = findCommand(sources.stream().map(File::getAbsolutePath).collect(joining(" "))) + " | xargs " + shellcheckBinary + " -f " + format + " --severity=" + task.getSeverity() + " " + task.getAdditionalArguments();
         command.add("sh");
         command.add("-c");
         command.add(cmd);

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
@@ -44,6 +44,7 @@ public class ShellcheckPlugin implements Plugin<Project> {
         taskMapping.map("shellcheckBinary", (Callable<String>) () -> extension.getShellcheckBinary());
         taskMapping.map("installer", (Callable<String>) () -> extension.getInstaller());
         taskMapping.map("projectDir", (Callable<File>) project::getProjectDir);
+        taskMapping.map("additionalArguments", (Callable<String>) () -> extension.getAdditionalArguments());
         final ConventionMapping extensionMapping = conventionMappingOf(extension);
         extensionMapping.map("reportsDir", (Callable<File>) () -> project.getExtensions().getByType(ReportingExtension.class).file("shellcheck"));
     }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
@@ -43,7 +43,7 @@ public class ShellcheckPlugin implements Plugin<Project> {
         taskMapping.map("severity", (Callable<String>) () -> extension.getSeverity());
         taskMapping.map("shellcheckBinary", (Callable<String>) () -> extension.getShellcheckBinary());
         taskMapping.map("installer", (Callable<String>) () -> extension.getInstaller());
-        taskMapping.map("projectDir", (Callable<File>) project::getProjectDir);
+        taskMapping.map("workingDir", (Callable<File>) () -> extension.getWorkingDir());
         taskMapping.map("additionalArguments", (Callable<String>) () -> extension.getAdditionalArguments());
         final ConventionMapping extensionMapping = conventionMappingOf(extension);
         extensionMapping.map("reportsDir", (Callable<File>) () -> project.getExtensions().getByType(ReportingExtension.class).file("shellcheck"));


### PR DESCRIPTION
`additionalArgs` makes the plugin more flexible, as it does not necessarily need to be updated if future versions of shellcheck add new command line arguments. It also makes it possible for users to pass shellcheck that there currently doesn't exist a specific configuration setting for (such as the `--external-sources` flag).

`workingDir` is useful if the user has scripts that include additonal scripts, and they call Shellcheck with the --external-sources flag.
