### PR TITLE
Invoke shellcheck on each file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ This implies that no dependencies are required on the executing machine, except 
 [[sec:shellcheck_tasks]]
 == Tasks
 
-The Shellcheck plugin a task called `shellcheck` to the project.
+The Shellcheck plugin adds a task called `shellcheck` to the project.
 
 
 [[sec:shellcheck_extension]]
@@ -38,6 +38,9 @@ The Shellcheck plugin a task called `shellcheck` to the project.
 ----
 shellcheck {
     sources = files("src/shellScripts", "src/moreScripts")
+    sourceFiles = fileTree("scr/shellScripts") {
+       includes("**/*.sh")
+    }
     isIgnoreFailures = true
     isShowViolations = true
     shellcheckVersion = "v0.7.1"
@@ -51,8 +54,8 @@ shellcheck {
 ----
 
 * sources - Folders where the shell scripts are located. It will search recursively matching `.sh`, `.bash`,
-`.bash_login`, `.bash_logout`, `.bash_profile`, `.bashrc` and `.ksh` files. Matching on shell scripts with no extension
-is not supported yet.
+`.bash_login`, `.bash_logout`, `.bash_profile`, `.bashrc` and `.ksh` files. Don't set `sourceFiles` if you set `sources`.
+* sourceFiles - Files to check with shellcheck. Using `sourceFiles` gives complete control over what files are checked using shellcheck. Don't set `source` if you set `sourceFiles`.
 * isIgnoreFailures - Whether to allow the build to continue if there are warnings. Defaults to `false`.
 * isShowViolations - Whether rule violations are to be displayed on the console. Defaults to `true`.
 * isUseDocker - Whether to use docker image (true) or local shellcheck binary (false). Defaults to `true`.

--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ The Shellcheck plugin adds a task called `shellcheck` to the project.
 shellcheck {
     sources = files("src/shellScripts", "src/moreScripts")
     sourceFiles = fileTree("scr/shellScripts") {
-       includes("**/*.sh")
+       includes("**/*.txt")
     }
     isIgnoreFailures = true
     isShowViolations = true
@@ -55,7 +55,7 @@ shellcheck {
 
 * sources - Folders where the shell scripts are located. It will search recursively matching `.sh`, `.bash`,
 `.bash_login`, `.bash_logout`, `.bash_profile`, `.bashrc` and `.ksh` files. Don't set `sourceFiles` if you set `sources`.
-* sourceFiles - Files to check with shellcheck. Using `sourceFiles` gives complete control over what files are checked using shellcheck. Don't set `source` if you set `sourceFiles`.
+* sourceFiles - Files to check with shellcheck. Using `sourceFiles` gives complete control over what files are checked using shellcheck.
 * isIgnoreFailures - Whether to allow the build to continue if there are warnings. Defaults to `false`.
 * isShowViolations - Whether rule violations are to be displayed on the console. Defaults to `true`.
 * isUseDocker - Whether to use docker image (true) or local shellcheck binary (false). Defaults to `true`.
@@ -87,6 +87,20 @@ tasks.withType<Shellcheck>().configureEach {
 XML generated report comes from `shellcheck -f checkstyle`, therefore you can get inspiration from https://github.com/checkstyle/contribution/tree/master/xsl[a sample Checkstyle stylesheet.]
 
 TXT generated report comes from `shellcheck -f tty`.
+
+[[sec:shellcheck_performance]]
+== Performance
+
+Using Docker is slower than using a locally installed shellcheck binary since there is a cost to starting up a Docker container.
+
+Additionally, using `sourceFiles` is slower than using `sources` (particularly when also using Docker). When script files
+are provided using `sourceFiles`, shellcheck is invoked for each file. In contrast, when using `sources`, shellcheck is
+invoked only once for all the scripts found in the directories identified by `sources`.
+
+Despite the performance penalty, `sourceFiles` is useful if you need to check scripts which do not have a standard shell
+extension (or no extension at all). Using `sourceFiles` also avoids issues related to command length (if you have a lot
+of shell files to check, using `sources` could fail because the resulting shellcheck command could exceed the shell's
+maximum command length).
 
 [[sec:shellcheck_testing]]
 == Testing

--- a/shellcheck/build.gradle.kts
+++ b/shellcheck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.felipefzdz.gradle.shellcheck"
-version = "1.4.2"
+version = "1.4.3-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
+++ b/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
@@ -30,6 +30,29 @@ shellcheck {
         !report.contains("script_with_violations_wrong_extension.txt")
     }
 
+    def "accept individual source files"() {
+        given:
+        buildFile << """
+shellcheck {
+    sourceFiles = fileTree("${resources.absolutePath}/with_violations") {
+        include("script_with_violations_wrong_extension.txt")
+    }
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+}
+"""
+
+        when:
+        def result = runner().buildAndFail()
+
+        then:
+        result.getOutput().contains("Shellcheck files with violations: 1")
+        result.getOutput().contains("Shellcheck violations by severity: 2")
+
+        def report = new File(testProjectDir.root, "build/reports/shellcheck/shellcheck.html").text
+        assert report.contains("script_with_violations_wrong_extension.txt");
+    }
+
     def "pass the build when no script in the folder has violations"() {
         given:
         buildFile << """

--- a/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
+++ b/shellcheck/src/functionalTest/groovy/com/felipefzdz/gradle/shellcheck/BaseShellcheckPluginFuncTest.groovy
@@ -30,7 +30,7 @@ shellcheck {
         !report.contains("script_with_violations_wrong_extension.txt")
     }
 
-    def "accept individual source files"() {
+    def "fail the build when some scripts given with sourceFiles contain violations"() {
         given:
         buildFile << """
 shellcheck {
@@ -66,6 +66,49 @@ shellcheck {
         expect:
         runner().build()
     }
+
+    def "sources and sourceFiles can be used together"() {
+        given:
+        buildFile << """
+shellcheck {
+    sources = files("${resources.absolutePath}/with_violations")
+    sourceFiles = fileTree("${resources.absolutePath}/with_violations") {
+        include("script_with_violations_wrong_extension.txt")
+    }
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+}
+"""
+        when:
+        def result = runner().buildAndFail()
+
+        then:
+        result.getOutput().contains("Shellcheck files with violations: 9")
+        result.getOutput().contains("Shellcheck violations by severity: 3")
+
+        def report = new File(testProjectDir.root, "build/reports/shellcheck/shellcheck.html").text
+        ["script_with_violations.bash", "script_with_violations.bash_login", "script_with_violations.bash_logout",
+         "script_with_violations.bash_profile", "script_with_violations.bashrc", "script_with_violations.ksh",
+         "script_with_violations.sh", "script_with_violations_2.sh", "script_with_violations_wrong_extension.txt"].each {
+            assert report.contains(it)
+        }
+    }
+
+    def "pass the build when no script given with sourceFiles has violations"() {
+        given:
+        buildFile << """
+shellcheck {
+    sourceFiles = fileTree("${resources.absolutePath}/without_violations") {
+        exclude("**/*.txt")
+    }
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+}
+"""
+        expect:
+        runner().build()
+    }
+
 
     def "ensure cacheability"() {
         given:
@@ -117,11 +160,27 @@ shellcheck {
         runner().build()
     }
 
-    def "not fail when no files are specified"() {
+    def "not fail when no source dirs are specified"() {
         given:
         buildFile << """
 shellcheck {
     sources = files("${resources.absolutePath}/no_shell_scripts")
+    useDocker = $useDocker
+    shellcheckBinary = "$shellcheckBinary"
+}
+"""
+
+        expect:
+        runner().build()
+    }
+
+    def "not fail when no sourceFiles are specified"() {
+        given:
+        buildFile << """
+shellcheck {
+    sourceFiles = fileTree("${resources.absolutePath}/no_shell_scripts") {
+        exclude("**/*")
+    }
     useDocker = $useDocker
     shellcheckBinary = "$shellcheckBinary"
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
@@ -15,16 +15,9 @@ public class Shell {
     static String run(String command, File projectDir, Logger logger) throws IOException, InterruptedException {
         return run(asList(command.split("\\s+")), projectDir, logger);
     }
+
     static String run(List<String> command, File workingDir, Logger logger) throws IOException, InterruptedException {
-        ProcessBuilder builder = new ProcessBuilder(command)
-                .directory(workingDir)
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectErrorStream(true);
-        prepareEnvironment(logger, builder.environment());
-
-        builder.redirectErrorStream(true);
-
-        Process process = builder.start();
+        Process process = start(command, workingDir, logger);
 
         StringBuilder processOutput = new StringBuilder();
 
@@ -37,6 +30,18 @@ public class Shell {
             process.waitFor();
         }
         return processOutput.toString().trim();
+    }
+
+    static Process start(List<String> command, File workingDir, Logger logger) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(command)
+                .directory(workingDir)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectErrorStream(true);
+        prepareEnvironment(logger, builder.environment());
+
+        builder.redirectErrorStream(true);
+
+        return builder.start();
     }
 
     private static void prepareEnvironment(Logger logger, final Map<String, String> environment) {

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shell.java
@@ -15,9 +15,16 @@ public class Shell {
     static String run(String command, File projectDir, Logger logger) throws IOException, InterruptedException {
         return run(asList(command.split("\\s+")), projectDir, logger);
     }
-
     static String run(List<String> command, File workingDir, Logger logger) throws IOException, InterruptedException {
-        Process process = start(command, workingDir, logger);
+        ProcessBuilder builder = new ProcessBuilder(command)
+                .directory(workingDir)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectErrorStream(true);
+        prepareEnvironment(logger, builder.environment());
+
+        builder.redirectErrorStream(true);
+
+        Process process = builder.start();
 
         StringBuilder processOutput = new StringBuilder();
 
@@ -30,18 +37,6 @@ public class Shell {
             process.waitFor();
         }
         return processOutput.toString().trim();
-    }
-
-    static Process start(List<String> command, File workingDir, Logger logger) throws IOException {
-        ProcessBuilder builder = new ProcessBuilder(command)
-                .directory(workingDir)
-                .redirectOutput(ProcessBuilder.Redirect.PIPE)
-                .redirectErrorStream(true);
-        prepareEnvironment(logger, builder.environment());
-
-        builder.redirectErrorStream(true);
-
-        return builder.start();
     }
 
     private static void prepareEnvironment(Logger logger, final Map<String, String> environment) {

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
@@ -40,6 +40,8 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
     private File workingDir;
     private String additionalArguments;
 
+    private String dockerContainerId;
+
     public Shellcheck() {
         this.reports = (ShellcheckReports) getObjectFactory().newInstance(ShellcheckReportsImpl.class, this);
     }
@@ -228,5 +230,14 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
 
     public void setAdditionalArguments(String additionalArguments) {
         this.additionalArguments = additionalArguments;
+    }
+
+    @Internal
+    public String getDockerContainerId() {
+        return dockerContainerId;
+    }
+
+    public void setDockerContainerId(String dockerContainerId) {
+        this.dockerContainerId = dockerContainerId;
     }
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.util.ClosureBackedAction;
 
@@ -26,6 +27,7 @@ import java.io.File;
 public class Shellcheck extends ConventionTask implements VerificationTask, Reporting<ShellcheckReports> {
 
     private FileCollection sources;
+    private FileCollection sourceFiles;
 
     private final ShellcheckReports reports;
     private boolean showViolations = true;
@@ -54,12 +56,24 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
     public FileCollection getSources() {
         return sources;
     }
 
     public void setSources(FileCollection sources) {
         this.sources = sources;
+    }
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    public FileCollection getSourceFiles() {
+        return sourceFiles;
+    }
+
+    public void setSourceFiles(FileCollection sourceFiles) {
+        this.sourceFiles = sourceFiles;
     }
 
     /**

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/Shellcheck.java
@@ -40,8 +40,6 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
     private File workingDir;
     private String additionalArguments;
 
-    private String dockerContainerId;
-
     public Shellcheck() {
         this.reports = (ShellcheckReports) getObjectFactory().newInstance(ShellcheckReportsImpl.class, this);
     }
@@ -230,14 +228,5 @@ public class Shellcheck extends ConventionTask implements VerificationTask, Repo
 
     public void setAdditionalArguments(String additionalArguments) {
         this.additionalArguments = additionalArguments;
-    }
-
-    @Internal
-    public String getDockerContainerId() {
-        return dockerContainerId;
-    }
-
-    public void setDockerContainerId(String dockerContainerId) {
-        this.dockerContainerId = dockerContainerId;
     }
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckExtension.java
@@ -11,6 +11,7 @@ public class ShellcheckExtension extends CodeQualityExtension {
     private final Project project;
 
     private FileCollection sources;
+    private FileCollection sourceFiles;
     private boolean showViolations = true;
     private String shellcheckVersion = "v0.7.1";
     private String severity = "style";
@@ -31,6 +32,14 @@ public class ShellcheckExtension extends CodeQualityExtension {
 
     public void setSources(FileCollection sources) {
         this.sources = sources;
+    }
+
+    public FileCollection getSourceFiles() {
+        return sourceFiles;
+    }
+
+    public void setSourceFiles(FileCollection sourceFiles) {
+        this.sourceFiles = sourceFiles;
     }
 
     /**
@@ -110,4 +119,5 @@ public class ShellcheckExtension extends CodeQualityExtension {
     public void setWorkingDir(File workingDir) {
         this.workingDir = workingDir;
     }
+
 }

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckInvoker.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckInvoker.java
@@ -3,6 +3,7 @@ package com.felipefzdz.gradle.shellcheck;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.internal.logging.ConsoleRenderer;
 import org.w3c.dom.Document;
@@ -25,6 +26,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.felipefzdz.gradle.shellcheck.Shell.run;
+import static com.felipefzdz.gradle.shellcheck.Shell.start;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -34,22 +36,23 @@ public class ShellcheckInvoker {
 
     public static void invoke(Shellcheck task) {
         maybeInstallShellcheck(task);
-        final ShellcheckReports reports = task.getReports();
-        final File xmlDestination = calculateReportDestination(task, reports.getXml());
+        maybeWithDocker(task, () -> {
+            final ShellcheckReports reports = task.getReports();
+            final File xmlDestination = calculateReportDestination(task, reports.getXml());
 
-        handleCheckstyleReport(task, xmlDestination).ifPresent(parsedReport -> {
-            handleTtyReport(task, reports, calculateReportDestination(task, reports.getTxt()));
-            handleHtmlReport(reports, xmlDestination);
-            calculateReportSummary(parsedReport).ifPresent(reportSummary -> {
-                final String message = getMessage(reports, reportSummary);
-                if (task.getIgnoreFailures()) {
-                    task.getLogger().warn(message);
-                } else {
-                    throw new GradleException(message);
-                }
+            handleCheckstyleReport(task, xmlDestination).ifPresent(parsedReport -> {
+                handleTtyReport(task, reports, calculateReportDestination(task, reports.getTxt()));
+                handleHtmlReport(reports, xmlDestination);
+                calculateReportSummary(parsedReport).ifPresent(reportSummary -> {
+                    final String message = getMessage(reports, reportSummary);
+                    if (task.getIgnoreFailures()) {
+                        task.getLogger().warn(message);
+                    } else {
+                        throw new GradleException(message);
+                    }
+                });
             });
         });
-
     }
 
     private static void maybeInstallShellcheck(Shellcheck task) {
@@ -178,7 +181,8 @@ public class ShellcheckInvoker {
             task.getLogger().debug("source files: " + sources);
         }
 
-        maybePrepareCommandToUserDocker(command, task.getWorkingDir(), sources, task.getShellcheckVersion(), task.isUseDocker());
+        task.getLogger().debug("Docker container ID: " + task.getDockerContainerId());
+        maybePrepareCommandToUserDocker(command, task.getDockerContainerId(), task.isUseDocker());
         final String shellcheckBinary = task.isUseDocker() ? "shellcheck" : task.getShellcheckBinary();
         String cmd = shellcheckBinary + " -f " + format + " --severity=" + task.getSeverity() + " " + task.getAdditionalArguments();
         command.add("sh");
@@ -198,22 +202,55 @@ public class ShellcheckInvoker {
         }).collect(Collectors.toList());
     }
 
-    private static void maybePrepareCommandToUserDocker(List<String> command, File workingDir, Set<File> sources, String shellcheckVersion, boolean useDocker) {
+    private static void maybePrepareCommandToUserDocker(List<String> command, String containerId, boolean useDocker) {
         if (useDocker) {
             command.add("docker");
-            command.add("run");
-            command.add("--rm");
-
-            command.add("-v");
-            command.add(workingDir.getAbsolutePath() + ":" + workingDir.getAbsolutePath());
-            command.add("-w");
-            command.add(workingDir.getAbsolutePath());
-            command.add("koalaman/shellcheck-alpine:" + shellcheckVersion);
+            command.add("exec");
+            command.add(containerId);
         }
     }
 
-    private static String findCommand(String sources) {
-        return "/usr/bin/find " + sources + " -type f \\( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.bashrc' -o -name '*.bash_profile' -o -name '*.bash_login' -o -name '*.bash_logout' \\)";
+    private static void maybeWithDocker(Shellcheck task, Runnable f) {
+        if(task.isUseDocker()) {
+            String containerId = startDocker(task.getWorkingDir(), task.getShellcheckVersion(), task.getLogger());
+            task.setDockerContainerId(containerId);
+            try {
+                f.run();
+            } finally {
+                stopDocker(containerId, task.getWorkingDir(), task.getLogger());
+            }
+        } else {
+            f.run();
+        }
+    }
+
+    private static String startDocker(File workingDir, String shellcheckVersion, Logger logger) {
+        List<String> command = new ArrayList<>();
+        command.add("docker");
+        command.add("run");
+        command.add("-it");
+        command.add("--rm");
+        command.add("--detach");
+        command.add("-v");
+        command.add(workingDir.getAbsolutePath() + ":" + workingDir.getAbsolutePath());
+        command.add("-w");
+        command.add(workingDir.getAbsolutePath());
+        command.add("koalaman/shellcheck-alpine:" + shellcheckVersion);
+
+        try {
+            logger.debug("Starting docker with " + String.join(" ", command));
+            return run(command, workingDir, logger);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleException("Failed to start docker: " + e.getMessage(), e);
+        }
+    }
+
+    private static void stopDocker(String containerId, File workingDir, Logger logger) {
+        try {
+            run("docker stop " + containerId, workingDir, logger);
+        } catch (IOException | InterruptedException e) {
+            throw new GradleException("Failed to stop docker container " + containerId + ":" + e.getMessage(), e);
+        }
     }
 
     private static String getMessage(ShellcheckReports reports, ReportSummary reportSummary) {

--- a/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
+++ b/shellcheck/src/main/java/com/felipefzdz/gradle/shellcheck/ShellcheckPlugin.java
@@ -36,6 +36,7 @@ public class ShellcheckPlugin implements Plugin<Project> {
     private void configureTaskConventionMapping(Shellcheck task, Project project) {
         ConventionMapping taskMapping = task.getConventionMapping();
         taskMapping.map("sources", (Callable<FileCollection>) () -> extension.getSources());
+        taskMapping.map("sourceFiles", (Callable<FileCollection>) () -> extension.getSourceFiles());
         taskMapping.map("ignoreFailures", (Callable<Boolean>) () -> extension.isIgnoreFailures());
         taskMapping.map("showViolations", (Callable<Boolean>) () -> extension.isShowViolations());
         taskMapping.map("useDocker", (Callable<Boolean>) () -> extension.isUseDocker());


### PR DESCRIPTION
Invoking shellcheck on each file individually has the following advantages:

  1. Allows the user to specify the exact set of files to invoke shellcheck on
     using regular Gradle syntax. This can be done by setting the new sourceFiles
     property instead of the original sources property.

  2. Because of the first item above, users are now able to run shellcheck
     against files that do not have a well-known extension (including files that
     have no extension).

  3. Better supports running shellcheck with --external-sources and
     --checked-sourced. In this particular use-case, the users typically want to
     include the main scripts that source other scripts, but exclude the other
     scripts (since they're already checked when the main scripts taht source them
     are checked).

  4. Avoids hitting a particular shell's maximum command line limit length (if
     there were a lot of sources).

There is a downside to this approach: it is slower than the original approach.
In particular, running shellcheck with docker is noticably slower. But the
benefits probably outweigh the downsides.