### PR TITLE
Fix Github check workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,4 +19,4 @@ jobs:
           java-version: 11
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-      - run: "./gradlew :check"
+      - run: "./gradlew check"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The root `:check` task is gone since the latest update, though the workflow hasn't been updated.